### PR TITLE
Correct dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["xml", "json"]
 readme = "README.md"
 
 [dependencies]
-log = "0"
+log = "0.4"
 serde = { version = "1", features = ["rc"] }
 serde_json = "1"
 quick-xml = { version = "0.19", features = ["serde"] }


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.