### PR TITLE
Update quick_xml dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 log = "0.4"
 serde = { version = "1", features = ["rc"] }
 serde_json = "1"
-quick-xml = { version = "0.19", features = ["serde"] }
+quick-xml = { version = "0.28.2", features = ["serde"] }
 
 [dev-dependencies]
 pretty_env_logger = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xmltojson"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["R. Tyler Croy <rtyler@brokenco.de>"]
 edition = "2018"
 description = "A simple crate for converting XML to JSON"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use serde_json::{Map, Value};
 #[derive(Debug)]
 pub struct Error {}
 
-fn read(mut reader: &mut Reader<&[u8]>, depth: u64) -> Value {
+fn read(reader: &mut Reader<&[u8]>, depth: u64) -> Value {
     let mut buf = Vec::new();
     let mut values = Vec::new();
     let mut node = Map::new();
@@ -25,7 +25,7 @@ fn read(mut reader: &mut Reader<&[u8]>, depth: u64) -> Value {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(ref e)) => {
                 if let Ok(name) = String::from_utf8(e.name().into_inner().to_vec()) {
-                    let mut child = read(&mut reader, depth + 1);
+                    let mut child = read(reader, depth + 1);
                     let mut attrs = Map::new();
                     debug!("{} children: {:?}", name, child);
 


### PR DESCRIPTION
Adding xmltojson dependency to a project give this compiler warning:

```
warning: the following packages contain code that will be rejected by a future version of Rust: quick-xml v0.19.0
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 494`
```

To avoid xmltojson being unusable in the future, updating quick-xml is necessary. Unfortunately, it has some breaking changes so I had to edit the code to reflect those changes. I also ran `cargo clippy` to fix some minors warnings.

All the tests pass without editing them.