### PR TITLE
Publish generic read function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,11 +11,12 @@ use log::*;
 use quick_xml::events::Event;
 use quick_xml::Reader;
 use serde_json::{Map, Value};
+use std::io::BufRead;
 
 #[derive(Debug)]
 pub struct Error {}
 
-fn read(reader: &mut Reader<&[u8]>, depth: u64) -> Value {
+pub fn read<R: BufRead>(reader: &mut Reader<R>, depth: u64) -> Value {
     let mut buf = Vec::new();
     let mut values = Vec::new();
     let mut node = Map::new();


### PR DESCRIPTION
This suggested change requires some context: I came across this solution while looking into some [reported shortcomings of my own quick-xml usage in another project](https://github.com/simonrupf/convert2json/issues/91). When experimenting with this library locally, I needed to be able to directly access the `read` function, as I use serde_json slightly differently and also needed to pass a more generic reader, so used the `BufRead` trait to express what the function needs from it.

Clearly, this breaks the current API, though it should not impact existing users of the library. But I do understand that this may be a change that is out of scope for this project. I can always look into incorporating this solution in another way in my project, but of course I'd first like to try and propose to change it in here, so others can benefit as well.