### PR TITLE
update to quick-xml 0.38.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 log = "0.4"
 serde = { version = "1", features = ["rc"] }
 serde_json = "1"
-quick-xml = { version = "0.37.2", features = ["serialize"] }
+quick-xml = { version = "0.38.0", features = ["serialize"] }
 
 [dev-dependencies]
 pretty_env_logger = "0"


### PR DESCRIPTION
The new version changed how to decode text events and introduces XML entity events. This necessitates dealing with trims directly, as doing so globally would trim spaces between text and entity, which it didn't before, when those got decoded as part of a text. I've also added a test for an ampersand entity in a text.