### PR TITLE
Make logs disableable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xmltojson"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["R. Tyler Croy <rtyler@brokenco.de>"]
 edition = "2018"
 description = "A simple crate for converting XML to JSON"
@@ -8,13 +8,17 @@ homepage = "https://github.com/rtyler/xmltojson"
 repository = "https://github.com/rtyler/xmltojson"
 license = "LGPL-3.0+"
 keywords = ["xml", "json"]
-readme = "README.md"
+readme = "README.adoc"
 
 [dependencies]
-log = "0.4"
+log = { version = "0.4", optional = true }
 serde = { version = "1", features = ["rc"] }
 serde_json = "1"
 quick-xml = { version = "0.38.0", features = ["serialize"] }
+
+[features]
+default = ["log"]
+log = ["dep:log"]
 
 [dev-dependencies]
 pretty_env_logger = "0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,13 +7,20 @@
 #[macro_use]
 extern crate serde_json;
 
-use log::*;
 use quick_xml::escape::resolve_predefined_entity;
 use quick_xml::events::Event;
 use quick_xml::Reader;
 use serde_json::{to_value, Map, Value};
 use std::io::BufRead;
 use std::mem::take;
+
+macro_rules! debug {
+    ($($x:tt)*) => (
+        #[cfg(feature = "log")] {
+            log::debug!($($x)*)
+        }
+    )
+}
 
 #[derive(Debug)]
 pub struct Error {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ use serde_json::{to_value, Map, Value};
 use std::io::BufRead;
 use std::mem::take;
 
+#[allow(unused)]
 macro_rules! debug {
     ($($x:tt)*) => (
         #[cfg(feature = "log")] {


### PR DESCRIPTION
This lib creates a lot of debug logs when converting an XML to a JSON. While it's very useful for debugging purposes, it costs a lot of time en production settings, making a few seconds operation last a few minutes because of io.

Now, the `log` dependency is now optional behind a `log` feature. To not change the behavior of the crate for other users, this feature is enabled by default. If you think it should be disabled by default, feel free to remove `default = ["log"]` in Cargo.toml

The crate now calls a internal version of the `debug!` macro, calling `log::debug!` if logs are enabled or removing the call if logs are disabled. It's the method used by rust for optional logs ([example in official rand crate](https://github.com/rust-random/rand/blob/master/src/lib.rs))

Here you can find a test with 45 XML conversion to show the difference in performance
[With logs](https://github.com/user-attachments/files/23834905/logs.log)
[Without logs](https://github.com/user-attachments/files/23834906/no_logs.log)

A `cargo test` was done. No regression detected